### PR TITLE
Drop Python 2.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - 2.6
   - 2.7
   - 3.3
   - 3.4

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -8,8 +8,8 @@ want to convince me that your style is better.
 
 * `PEP 8`_, the style guide, should be followed where possible.
 * `PEP 257`_, the docstring style guide, should be followed at all times
-* While support for Python versions prior to v2.6 may be added in the future if
-  such a need were to arise, you are encouraged to use v2.6 features now.
+* While support for Python versions prior to v2.7 may be added in the future if
+  such a need were to arise, you are encouraged to use v2.7 features now.
 * All new classes and methods should be accompanied by new tests, and Sphinx_
   ``autodoc``-compatible descriptions.
 

--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ Extra tag     Dependencies
 ``template``  html2text_, Jinja2_, Pygments_
 ============  ==============================
 
-It should work with any version of Python_ 2.6 or newer, including Python 3.
+It should work with any version of Python_ 2.7 or newer, including Python 3.
 If ``jnrbase`` doesn't work with the version of Python you have installed, file
 an issue_ and I'll endeavour to fix it.
 

--- a/doc/api/pip_support.rst
+++ b/doc/api/pip_support.rst
@@ -15,4 +15,4 @@ Examples
 .. doctest::
 
     >>> parse_requires('extra/requirements-test.txt')
-    ['click>=3.0', 'configobj>=0.5.0', 'ciso8601>=1.0.1', 'pytz', 'httplib2', 'html2text', 'Jinja2>=2', 'Pygments', 'expecter>=0.2.2', 'hiro>=0.1.7', 'nose2[coverage_plugin]>=0.5.0', 'mock>=0.7.1;python_version<"3.3"', 'unittest2<0.6,>=0.5.1;python_version<"2.7"']
+    ['click>=3.0', 'configobj>=0.5.0', 'ciso8601>=1.0.1', 'pytz', 'httplib2', 'html2text', 'Jinja2>=2', 'Pygments', 'expecter>=0.2.2', 'hiro>=0.1.7', 'nose2[coverage_plugin]>=0.5.0', 'mock>=0.7.1;python_version<"3.3"']

--- a/extra/requirements-test.txt
+++ b/extra/requirements-test.txt
@@ -5,4 +5,3 @@ nose2[coverage_plugin]>=0.5.0
 
 # Conditionals
 mock>=0.7.1;python_version<"3.3"
-unittest2<0.6,>=0.5.1;python_version<"2.7"

--- a/jnrbase/compat.py
+++ b/jnrbase/compat.py
@@ -17,8 +17,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-import subprocess
-
 from sys import version_info
 
 PY2 = version_info[0] == 2
@@ -59,33 +57,3 @@ if PY2:  # pragma: Python 2
         return klass
 else:  # pragma: Python 3
     mangle_repr_type = lambda x: x
-
-
-def check_output(args, **kwargs):
-    """Simple check_output implementation for Python 2.6 compatibility.
-
-    Note:
-        This hides stderr, unlike the normal check_output function.
-
-    Args:
-        args (list): Command and arguments to call
-
-    Returns:
-        str: Command output
-
-    Raises:
-        subprocess.CalledProcessError: If command execution fails
-    """
-    try:
-        output = subprocess.check_output(args, stderr=subprocess.PIPE,
-                                         **kwargs)
-    except AttributeError:
-        process = subprocess.Popen(args, stdout=subprocess.PIPE,
-                                   stderr=subprocess.PIPE, **kwargs)
-        output, _ = process.communicate()
-        retcode = process.poll()
-        if retcode:
-            raise subprocess.CalledProcessError(retcode, args[0])
-    if not PY2:  # pragma: Python 3
-        output = output.decode('ascii', 'replace')
-    return output

--- a/jnrbase/git.py
+++ b/jnrbase/git.py
@@ -17,9 +17,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from subprocess import CalledProcessError
+from subprocess import (check_output, CalledProcessError)
 
-from jnrbase.compat import check_output
+from jnrbase.compat import PY2
 from jnrbase.context import chdir
 
 
@@ -46,4 +46,6 @@ def find_tag(matcher='v[0-9]*', strict=True, git_dir='.'):
                 raise
             stdout = check_output(command + ['--always', ])
 
-        return stdout.strip()
+    if not PY2:  # pragma: Python 3
+        stdout = stdout.decode('ascii', 'replace')
+    return stdout.strip()

--- a/jnrbase/human_time.py
+++ b/jnrbase/human_time.py
@@ -43,11 +43,9 @@ def human_timestamp(timestamp):
     ]
     match_names = ['year', 'month', 'week', 'day', 'hour', 'minute', 'second']
 
-    delta = datetime.datetime.utcnow() - timestamp
-    # Switch to delta.total_seconds, if 2.6 support is dropped
-    seconds = delta.days * 86400 + delta.seconds
+    delta = int((datetime.datetime.utcnow() - timestamp).total_seconds())
     for scale in matches:
-        i = seconds // scale
+        i = delta // scale
         if i:
             name = match_names[matches.index(scale)]
             break

--- a/jnrbase/template.py
+++ b/jnrbase/template.py
@@ -122,13 +122,7 @@ def regexp(string, pattern, repl, count=0, flags=0):
     Returns:
         str: Text with substitutions applied
     """
-    if sys.version_info[:2] >= (2, 7):
-        return re.sub(pattern, repl, string, count, flags)
-    else:
-        # regexps are cached, so this uglier path is no better than the 2.7
-        # one.  Once 2.6 support disappears, so can this
-        match = re.compile(pattern, flags=flags)
-        return match.sub(repl, string, count)
+    return re.sub(pattern, repl, string, count, flags)
 
 
 @jinja_filter

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -17,42 +17,15 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from subprocess import CalledProcessError
-from sys import version_info
-
 from expecter import expect
 
-from jnrbase import compat
-
-from .utils import patch
+from jnrbase.compat import (mangle_repr_type, text)
 
 
 def test_mangle_repr_type():
-    @compat.mangle_repr_type
+    @mangle_repr_type
     class Test(object):
         def __repr__(self):
-            return compat.text("test")
+            return text("test")
     # This works on Python 2 or 3 by design
     expect(repr(Test())).isinstance(str)
-
-
-def test_check_output():
-    expect(compat.check_output(['echo', 'hello'])) == 'hello\n'
-
-
-def test_check_output_py26_compat():
-    if version_info[:2] == (2, 6):
-        expect(compat.check_output(['echo', 'hello'])) == 'hello\n'
-    else:
-        with patch('subprocess.check_output', side_effect=AttributeError):
-            expect(compat.check_output(['echo', 'hello'])) == 'hello\n'
-
-
-def test_check_output_py26_compat_fail():
-    if version_info[:2] == (2, 6):
-        with expect.raises(CalledProcessError):
-            compat.check_output(['false', ])
-    else:
-        with patch('subprocess.check_output', side_effect=AttributeError):
-            with expect.raises(CalledProcessError):
-                compat.check_output(['false', ])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -63,7 +63,6 @@ def test_colour_default():
 
 
 def test_colour_from_config():
-    with chdir('tests/data/config'):
-        with patch_env(clear=True):
-            cfg = config.read_configs('jnrbase', local=True)
+    with chdir('tests/data/config'), patch_env(clear=True):
+        cfg = config.read_configs('jnrbase', local=True)
     expect(cfg.colour) is False

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -32,6 +32,5 @@ def test_chdir():
 
 
 def test_chdir_missing():
-    with expect.raises(OSError):
-        with context.chdir('missing_dir'):
+    with expect.raises(OSError), context.chdir('missing_dir'):
             pass

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -17,12 +17,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from sys import version_info
-try:
-    from unittest import skipIf
-except ImportError:
-    from unittest2 import skipIf
-
 from expecter import expect
 
 from jnrbase.debug import (DebugPrint, enter, exit, noisy_wrap, sys)
@@ -30,11 +24,6 @@ from jnrbase.debug import (DebugPrint, enter, exit, noisy_wrap, sys)
 from .utils import mock_stdout
 
 
-skip26 = skipIf(version_info[:2] == (2, 6),
-                'Requires dirty hacks for low value')
-
-
-@skip26
 @mock_stdout
 def test_enter_no_arg(stdout):
     @enter
@@ -54,7 +43,6 @@ def test_enter_with_message(stdout):
     expect(stdout.getvalue()).contains('custom message\n')
 
 
-@skip26
 @mock_stdout
 def test_exit_no_arg(stdout):
     @exit

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -54,9 +54,8 @@ def tarball_data(tar_name):
 
 @requires_git
 def test_empty_repo():
-    with tarball_data('empty') as tree:
-        with expect.raises(CalledProcessError):
-            find_tag(git_dir=tree)
+    with tarball_data('empty') as tree, expect.raises(CalledProcessError):
+        find_tag(git_dir=tree)
 
 
 @requires_git

--- a/tests/test_httplib2_certs.py
+++ b/tests/test_httplib2_certs.py
@@ -50,9 +50,9 @@ def test_bundled():
 
 @mock_path_exists(False)
 def test_bundled_fail():
-    with patch.object(httplib2_certs, 'ALLOW_FALLBACK', False):
-        with expect.raises(RuntimeError):
-            httplib2_certs.find_certs()
+    with patch.object(httplib2_certs, 'ALLOW_FALLBACK', False), \
+         expect.raises(RuntimeError):
+        httplib2_certs.find_certs()
 
 
 @mock_platform('freebsd')
@@ -65,9 +65,9 @@ def test_freebsd_paths():
 @mock_platform('freebsd')
 @mock_path_exists(False)
 def test_freebsd_no_installed_certs():
-    with patch.object(httplib2_certs, 'ALLOW_FALLBACK', False):
-        with expect.raises(RuntimeError):
-            httplib2_certs.find_certs()
+    with patch.object(httplib2_certs, 'ALLOW_FALLBACK', False), \
+         expect.raises(RuntimeError):
+        httplib2_certs.find_certs()
 
 
 @params(

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -65,9 +65,3 @@ def test_custom_filter_fallthrough(filter, args, kwargs, expected, stdout):
     stdout.isatty.side_effect = lambda: False
     env = template.setup('jnrbase')
     expect(env.filters[filter](*args, **kwargs)) == expected
-
-
-@patch.object(sys, 'version_info', (2, 6, 0))
-def test_python26_style_flagless_sub():
-    env = template.setup('jnrbase')
-    expect(env.filters['regexp']('test', 't', 'T')) == 'TesT'

--- a/tests/test_timer.py
+++ b/tests/test_timer.py
@@ -34,8 +34,7 @@ def test_timer(timeline):
 
 @mock_stdout
 def test_verbose_timer(stdout):
-    with Timeline() as timeline:
-        with Timer(verbose=True) as t:
-            timeline.forward(3600)
+    with Timeline() as timeline, Timer(verbose=True) as t:
+        timeline.forward(3600)
     expect(t.elapsed) >= 3600
     expect(stdout.getvalue()).contains('Elapsed: 36')

--- a/tests/test_xdg_basedir.py
+++ b/tests/test_xdg_basedir.py
@@ -96,10 +96,10 @@ def test_get_configs_macos():
 
 @mock_path_exists([True, False])
 def test_get_data():
-    with patch_env({'XDG_DATA_HOME': '~/.xdg/local'}):
-        with patch_env({'XDG_DATA_DIRS': '/usr/share:test2'}):
-            expect(xdg_basedir.get_data('jnrbase', 'photo.jpg')) == \
-                '/usr/share/jnrbase/photo.jpg'
+    with patch_env({'XDG_DATA_HOME': '~/.xdg/local'}), \
+         patch_env({'XDG_DATA_DIRS': '/usr/share:test2'}):
+        expect(xdg_basedir.get_data('jnrbase', 'photo.jpg')) == \
+               '/usr/share/jnrbase/photo.jpg'
 
 
 @mock_path_exists(False)


### PR DESCRIPTION
The last 2.6 system I had access to disappeared on Friday afternoon, however if others use it support can be re-added.