### PR TITLE
Drop Python 3.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - 3.5
   - 3.6
 install:
   - pip install -r extra/requirements-test.txt

--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ Extra tag     Dependencies
 ``template``  html2text_, Jinja2_ ≥ 2.9, Pygments_
 ============  ====================================
 
-It should work with any version of Python_ 3.5 or newer.  If ``jnrbase``
+It should work with any version of Python_ 3.6 or newer.  If ``jnrbase``
 doesn’t work with the version of Python you have installed, file an issue_ and
 I’ll endeavour to fix it.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ author = James Rowe
 author_email = jnrowe@gmail.com
 description = Common utility functionality
 keywords = library support utility
-python_requires = >=3.5
+python_requires = >=3.6
 py_modules = ca_certs_locater
 packages = jnrbase
 entry_points = {'console_scripts': ['jnrbase = jnrbase.cmdline:cli', ]}
@@ -52,7 +52,6 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3 :: Only

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -20,7 +20,7 @@
 
 from os import getcwd, getenv
 from re import escape
-from subprocess import PIPE, run
+from subprocess import check_output
 
 from pytest import raises
 
@@ -59,7 +59,6 @@ def test_env_unset():
 def test_env_subshell_support():
     assert getenv('NOT_SET') is None
     with context.env(NOT_SET='hello'):
-        # Switch to encoding kwarg when Python 3.5 support is dropped
-        out = run(['printenv', ], stdout=PIPE).stdout.decode()
+        out = check_output(['printenv', ], encoding='utf-8')
         assert 'NOT_SET=hello' in out.splitlines()
     assert getenv('NOT_SET') is None


### PR DESCRIPTION
This isn’t necessarily going to be merged [_yet_], as there are a few places that still don’t have even _this_ recent a Python release.  It is — however — a question of when and not if.